### PR TITLE
Merge sfrinaldi/pyproject.toml-fix into main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "GNU GENERAL PUBLIC LICENSE - Verison 3" }
 requires-python = ">=3.8"
 dependencies = [
-    "utils_config @ git+ssh://git@github.com/uasal/utils_config.git@develop" 
+    "utils_config @ git+https://github.com/uasal/utils_config.git@develop"  
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Applying correction to `pyproject.toml` for using https instead of ssh. Didn't get transferred over to here when editing / updating previously. 